### PR TITLE
Added support for native Lazy-loading images on WordPress 5.5 version.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 # Change log
 
+## [1.2.4]
+
+### Added
+- Added default WP 5.5 lazyloading.
 
 ## [[1.2.3]](https://github.com/lightspeeddevelopment/lsx-team/releases/tag/1.2.3) - 2020-03-30
 

--- a/classes/class-lsx-team-widget.php
+++ b/classes/class-lsx-team-widget.php
@@ -91,9 +91,7 @@ class LSX_Team_Widget extends WP_Widget {
 		if ( $tagline ) {
 			echo '<p class="tagline text-center">' . esc_html( $tagline ) . '</p>';
 		}
-		if ( 'true' === $carousel || true === $carousel ) {
-			add_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-		}
+
 		if ( class_exists( 'LSX_Team' ) ) {
 			lsx_team( array(
 				'columns' => $columns,
@@ -113,9 +111,7 @@ class LSX_Team_Widget extends WP_Widget {
 				'carousel' => $carousel,
 				'featured' => $featured,
 			) );
-			if ( 'true' === $carousel || true === $carousel ) {
-				remove_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-			}
+
 		};
 
 		if ( $button_text && $title_link ) {
@@ -346,27 +342,6 @@ class LSX_Team_Widget extends WP_Widget {
 		<?php
 	}
 
-	public function lazyload_slider_images( $img, $post_thumbnail_id, $size, $srcset, $image_url ) {
-		$lazyload = true;
-		if ( get_theme_mod( 'lsx_lazyload_status', '1' ) === false || ! apply_filters( 'lsx_lazyload_is_enabled', true ) ) {
-			$lazyload = false;
-		}
-		$lazy_img = '';
-		if ( true === $lazyload && '' !== $img ) {
-			$temp_lazy = wp_get_attachment_image_src( $post_thumbnail_id, $size );
-			if ( ! empty( $temp_lazy ) ) {
-				$lazy_img = $temp_lazy[0];
-			}
-			$img = '<img alt="' . the_title_attribute( 'echo=0' ) . '" class="attachment-responsive wp-post-image lsx-responsive" ';
-			if ( $srcset ) {
-				$img .= 'data-lazy="' . $lazy_img . '" srcset="' . esc_attr( $image_url ) . '" ';
-			} else {
-				$img .= 'data-lazy="' . esc_url( $image_url ) . '" ';
-			}
-			$img .= '/>';
-		}
-		return $img;
-	}
 }
 
 /**

--- a/classes/class-lsx-team.php
+++ b/classes/class-lsx-team.php
@@ -72,9 +72,9 @@ class LSX_Team {
 
 		if ( empty( $thumbnail ) ) {
 			if ( $this->options['display'] && ! empty( $this->options['display']['team_placeholder'] ) ) {
-				$thumbnail = '<img class="img-responsive wp-post-image" src="' . $this->options['display']['team_placeholder'] . '" width="' . $size . '" />';
+				$thumbnail = '<img loading="lazy" class="img-responsive wp-post-image" src="' . $this->options['display']['team_placeholder'] . '" width="' . $size . '" />';
 			} else {
-				$thumbnail = '<img class="img-responsive wp-post-image" src="https://www.gravatar.com/avatar/none?d=mm&s=' . $size . '" width="' . $size . '" />';
+				$thumbnail = '<img loading="lazy" class="img-responsive wp-post-image" src="https://www.gravatar.com/avatar/none?d=mm&s=' . $size . '" width="' . $size . '" />';
 			}
 		}
 

--- a/templates/content-archive-team-careers-cta.php
+++ b/templates/content-archive-team-careers-cta.php
@@ -10,7 +10,7 @@
 
 <?php if ( isset( $lsx_team->options['display'] ) && ! empty( $lsx_team->options['display']['team_careers_cta_enable'] ) ) : ?>
 	<?php
-		$thumbnail = '<img class="img-responsive wp-post-image" src="https://www.gravatar.com/avatar/none?d=mm&s=170" width="170" />';
+		$thumbnail = '<img loading="lazy" class="img-responsive wp-post-image" src="https://www.gravatar.com/avatar/none?d=mm&s=170" width="170" />';
 		$title = $lsx_team->options['display']['team_careers_cta_title'];
 		$tagline = $lsx_team->options['display']['team_careers_cta_tagline'];
 		$link_text = $lsx_team->options['display']['team_careers_cta_link_text'];


### PR DESCRIPTION
### Changes

Added support for native Lazy-loading images on WordPress 5.5 version.

### Benefits

- Support for WP 5.5 features.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/425

### Changelog Entry

#### Added
- Added support for native Lazy-loading images on WordPress 5.5 version.
